### PR TITLE
Add impersonation token to user social login

### DIFF
--- a/WebhostApi.php
+++ b/WebhostApi.php
@@ -126,12 +126,13 @@ class WebhostApi
      * @param $identifier
      * @return array
      */
-    public function userLoginSocial($email, $identifier)
+    public function userLoginSocial($email, $identifier, $impersonationToken = null)
     {
         $response = $this->client->post('v1/oauth/access_token', $this->getRequestOptions([
             'grant_type' => 'social',
             'username' => $email,
-            'password' => $identifier
+            'password' => $identifier,
+            'impersonation_token' => $impersonationToken,
         ]));
 
         return $this->transform($response);


### PR DESCRIPTION
Add `impersonation_token` to the post request, just like in the `userLogin()` method.
The default for `impersonation_token` is set to null.